### PR TITLE
fix: リネーム処理関連のリファクタリング.

### DIFF
--- a/utils/rename_file_act_add.py
+++ b/utils/rename_file_act_add.py
@@ -32,22 +32,30 @@ def rename_file_act_add(
         # ナンバリング有りver
         if is_add_numbering:
             for i, file in enumerate(rename_files, 1):
+                # 置換対象文字を含んでいない場合はスキップ
+                if file.count(replace_str) == 0:
+                    continue
+
                 shutil.copy2(file, file + ".bak")
 
                 dir_name = os.path.dirname(file)
-                extends = file.split(".")[-1]
+                # os.path.splitext で確実に拡張子を取得する
+                extend = os.path.splitext(file)[1]
 
                 new_name = os.path.join(
                     dir_name,
-                    f"{i}-{replace_str}-{file}.{extends}"
+                    f"{i}-{replace_str}-{file}{extend}"
                     if numbering == "y"
-                    else f"{file}-{replace_str}-{i}.{extends}",
+                    else f"{file}-{replace_str}-{i}{extend}",
                 )
                 print(file, new_name)
                 os.rename(file, new_name)
             return  # 無用な後続処理を避けるため明示的に処理終了
 
         for file in rename_files:
+            if file.count(replace_str) == 0:
+                continue
+
             shutil.copy2(file, file + ".bak")
             adjust_filename = (
                 f"{replace_str}-{file}" if is_begin else f"{file}-{replace_str}"

--- a/utils/rename_files_sys.py
+++ b/utils/rename_files_sys.py
@@ -85,8 +85,8 @@ def rename_files_sys(
             rename_file_act_regular(target_files, numbering, replace_all_str)
 
         elif mode == "part":
-            replace_str = input("置換結果となる文字列：")
-            target_str = input("置換したいファイル名の文字列：")
+            replace_str = input("リネーム前の対象文字列を入力：")
+            target_str = input("リネーム名を入力：")
             rename_file_act_regular(target_files, numbering, replace_str, target_str)
 
         elif mode == "add_begin":


### PR DESCRIPTION
- 同一拡張子ファイルの一括リネーム時におけるエラーハンドリングメソッド追加
- ` os.path.splitext(file)[1]`を使った確実な拡張子文字列の抽出方法に切り替え
- 部分置換処理におけるコード理解促進補助用の変数を追加